### PR TITLE
Fix typo for AKS helper hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As an alternative to the manual instructions detailed in this repo, you can call
 
 ## Prerequisites
 
-Use the [AKS helper](https://azure.github.io/Aks-Construction) to provision your cluster, and configure the helper as follows:
+Use the [AKS helper](https://azure.github.io/AKS-Construction) to provision your cluster, and configure the helper as follows:
 
 Keep the default options for:
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* AKS helper link was https://azure.github.io/Aks-Construction, with typo A**ks**-Construction. It directed to non-existing page with 404 result. Updated the hyper link to https://azure.github.io/AKS-Construction

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
No interaction with code. Just check the new hyperlink.
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Same as mentioned above.
```

## What to Check
Verify that the following are valid
* Check the new hyperlink for the redirection to the AKS helper page.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
None.