### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/deployapp.yml
+++ b/.github/workflows/deployapp.yml
@@ -152,10 +152,10 @@ jobs:
               "certmanager-production") CERTSOURCE="letsEncrypt" LEISSUER="letsencrypt-production" ;;
           esac
           echo "Using Certificate source $CERTSOURCE"
-          echo "::set-output name=CERTSOURCE::$CERTSOURCE"
+          echo "CERTSOURCE=$CERTSOURCE" >> "$GITHUB_OUTPUT"
 
           echo "Using Lets Encrypt Issuer $LEISSUER"
-          echo "::set-output name=LEISSUER::$LEISSUER"
+          echo "LEISSUER=$LEISSUER" >> "$GITHUB_OUTPUT"
 
       - name: Install the Java sample app
         env:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter